### PR TITLE
Fixing functionality for Export > PDF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,41 @@ RUN \
 	> /etc/apt/sources.list.d/nodesource.list && \
  apt-get update && \
  apt-get install -y \
-	nodejs && \
+	nodejs \ 
+	gconf-service \
+	libasound2 \
+	libatk1.0-0 \
+	libc6 \
+	libcairo2 \
+	libcups2 \
+	libdbus-1-3 \
+	libexpat1 \
+	libfontconfig1 \
+	libgcc1 \
+	libgconf-2-4 \
+	libgdk-pixbuf2.0-0 \
+	libglib2.0-0 \
+	libgtk-3-0 \
+	libnspr4 \
+	libpango-1.0-0 \
+	libpangocairo-1.0-0 \
+	libstdc++6 \
+	libx11-6 \
+	libx11-xcb1 \
+	libxcb1 \
+	libxcomposite1 \
+	libxcursor1 \
+	libxdamage1 \
+	libxext6 \
+	libxfixes3 \
+	libxi6 \
+	libxrandr2 \
+	libxrender1 \
+	libxss1 \
+	libxtst6 \
+	fonts-liberation \
+	libappindicator1 \
+	libnss3 && \
  echo "**** install dillinger ****" && \
  mkdir -p \
 	/app/dillinger && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,41 +19,41 @@ RUN \
 	> /etc/apt/sources.list.d/nodesource.list && \
  apt-get update && \
  apt-get install -y \
-	nodejs \ 
-	gconf-service \
-	libasound2 \
-	libatk1.0-0 \
-	libc6 \
-	libcairo2 \
-	libcups2 \
-	libdbus-1-3 \
-	libexpat1 \
-	libfontconfig1 \
-	libgcc1 \
-	libgconf-2-4 \
-	libgdk-pixbuf2.0-0 \
-	libglib2.0-0 \
-	libgtk-3-0 \
-	libnspr4 \
-	libpango-1.0-0 \
-	libpangocairo-1.0-0 \
-	libstdc++6 \
-	libx11-6 \
-	libx11-xcb1 \
-	libxcb1 \
-	libxcomposite1 \
-	libxcursor1 \
-	libxdamage1 \
-	libxext6 \
-	libxfixes3 \
-	libxi6 \
-	libxrandr2 \
-	libxrender1 \
-	libxss1 \
-	libxtst6 \
-	fonts-liberation \
-	libappindicator1 \
-	libnss3 && \
+        fonts-liberation \
+        gconf-service \
+        libappindicator1 \
+        libasound2 \
+        libatk1.0-0 \
+        libc6 \
+        libcairo2 \
+        libcups2 \
+        libdbus-1-3 \
+        libexpat1 \
+        libfontconfig1 \
+        libgcc1 \
+        libgconf-2-4 \
+        libgdk-pixbuf2.0-0 \
+        libglib2.0-0 \
+        libgtk-3-0 \
+        libnspr4 \
+        libnss3 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libstdc++6 \
+        libx11-6 \
+        libx11-xcb1 \
+        libxcb1 \
+        libxcomposite1 \
+        libxcursor1 \
+        libxdamage1 \
+        libxext6 \
+        libxfixes3 \
+        libxi6 \
+        libxrandr2 \
+        libxrender1 \
+        libxss1 \
+        libxtst6 \
+        nodejs && \
  echo "**** install dillinger ****" && \
  mkdir -p \
 	/app/dillinger && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -23,7 +23,41 @@ RUN \
 	> /etc/apt/sources.list.d/nodesource.list && \
  apt-get update && \
  apt-get install -y \
-	nodejs && \
+ 	nodejs \
+        gconf-service \
+        libasound2 \
+        libatk1.0-0 \
+        libc6 \
+        libcairo2 \
+        libcups2 \
+        libdbus-1-3 \
+        libexpat1 \
+        libfontconfig1 \
+        libgcc1 \
+        libgconf-2-4 \
+        libgdk-pixbuf2.0-0 \
+        libglib2.0-0 \
+        libgtk-3-0 \
+        libnspr4 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libstdc++6 \
+        libx11-6 \
+        libx11-xcb1 \
+        libxcb1 \
+        libxcomposite1 \
+        libxcursor1 \
+        libxdamage1 \
+        libxext6 \
+        libxfixes3 \
+        libxi6 \
+        libxrandr2 \
+        libxrender1 \
+        libxss1 \
+        libxtst6 \
+        fonts-liberation \
+        libappindicator1 \
+        libnss3 && \
  echo "**** install dillinger ****" && \
  mkdir -p \
 	/app/dillinger && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -23,8 +23,9 @@ RUN \
 	> /etc/apt/sources.list.d/nodesource.list && \
  apt-get update && \
  apt-get install -y \
- 	nodejs \
+        fonts-liberation \
         gconf-service \
+        libappindicator1 \
         libasound2 \
         libatk1.0-0 \
         libc6 \
@@ -39,6 +40,7 @@ RUN \
         libglib2.0-0 \
         libgtk-3-0 \
         libnspr4 \
+        libnss3 \
         libpango-1.0-0 \
         libpangocairo-1.0-0 \
         libstdc++6 \
@@ -55,9 +57,7 @@ RUN \
         libxrender1 \
         libxss1 \
         libxtst6 \
-        fonts-liberation \
-        libappindicator1 \
-        libnss3 && \
+        nodejs && \
  echo "**** install dillinger ****" && \
  mkdir -p \
 	/app/dillinger && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -23,8 +23,9 @@ RUN \
 	> /etc/apt/sources.list.d/nodesource.list && \
  apt-get update && \
  apt-get install -y \
-	nodejs \
+        fonts-liberation \
         gconf-service \
+        libappindicator1 \
         libasound2 \
         libatk1.0-0 \
         libc6 \
@@ -39,6 +40,7 @@ RUN \
         libglib2.0-0 \
         libgtk-3-0 \
         libnspr4 \
+        libnss3 \
         libpango-1.0-0 \
         libpangocairo-1.0-0 \
         libstdc++6 \
@@ -55,9 +57,7 @@ RUN \
         libxrender1 \
         libxss1 \
         libxtst6 \
-        fonts-liberation \
-        libappindicator1 \
-        libnss3 && \
+        nodejs && \
  echo "**** install dillinger ****" && \
  mkdir -p \
 	/app/dillinger && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -23,7 +23,41 @@ RUN \
 	> /etc/apt/sources.list.d/nodesource.list && \
  apt-get update && \
  apt-get install -y \
-	nodejs && \
+	nodejs \
+        gconf-service \
+        libasound2 \
+        libatk1.0-0 \
+        libc6 \
+        libcairo2 \
+        libcups2 \
+        libdbus-1-3 \
+        libexpat1 \
+        libfontconfig1 \
+        libgcc1 \
+        libgconf-2-4 \
+        libgdk-pixbuf2.0-0 \
+        libglib2.0-0 \
+        libgtk-3-0 \
+        libnspr4 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libstdc++6 \
+        libx11-6 \
+        libx11-xcb1 \
+        libxcb1 \
+        libxcomposite1 \
+        libxcursor1 \
+        libxdamage1 \
+        libxext6 \
+        libxfixes3 \
+        libxi6 \
+        libxrandr2 \
+        libxrender1 \
+        libxss1 \
+        libxtst6 \
+        fonts-liberation \
+        libappindicator1 \
+        libnss3 && \
  echo "**** install dillinger ****" && \
  mkdir -p \
 	/app/dillinger && \

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Here are some example snippets to help you get started creating a container.
 ```
 docker create \
   --name=dillinger \
+  --cap-add=SYS_ADMIN
   -e PUID=1000 \
   -e PGID=1000 \
   -e TZ=Europe/London \
@@ -85,6 +86,8 @@ services:
   dillinger:
     image: linuxserver/dillinger
     container_name: dillinger
+    cap_add:
+      - SYS_ADMIN
     environment:
       - PUID=1000
       - PGID=1000
@@ -102,6 +105,7 @@ Container images are configured using parameters passed at runtime (such as thos
 
 | Parameter | Function |
 | :----: | --- |
+| `--cap-add=SYS_ADMIN` | Necessary permissions for Chromium's export of PDFs |
 | `-p 8080` | The port for the Dillinger web interface |
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
@@ -216,3 +220,4 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 ## Versions
 
 * **31.05.19:** - Initial Release.
+* **20.08.20:** - Adding necessary packages and permissions for MD export to PDF functionality

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -11,3 +11,6 @@ i=/app/dillinger/configs
 # permissions
 chown -R abc:abc \
 	/config
+
+chown -R abc:abc \
+	/app/dillinger/public/


### PR DESCRIPTION
Fixing functionality for Export > PDF

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:

Adds necessary packages and fixes permissions for the file generation folder. Since the node app is running as user=ABC and the public folder is owned by user=root, users were experiencing permission failures when trying to generate PDFs.

## Benefits of this PR and context:

Issue #2 notes a couple users that were having an issue where doing the top nav's "EXPORT AS" > "PDF" were greated with a generic permission error for the public folder, it would happen to any user running this normally.

## How Has This Been Tested?

Built with: 

```
docker build \
  --no-cache \
  --pull \
  -t linuxserver/dillinger:latest .
```

Generated simple run command `docker run -it --cap-add=SYS_ADMIN -p 8080:8080 linuxserver/dillinger` and manually browsed to the page and manually exported to PDF.

This was only tested on an x86 system, arm procs were not tested for the lib packages

## Source / References:

For package selection of Puppeteer dependencies:
https://medium.com/@ssmak/how-to-fix-puppetteer-error-while-loading-shared-libraries-libx11-xcb-so-1-c1918b75acc3
Requirement for containerized Puppeteer as container can't generate sandbox
https://github.com/puppeteer/puppeteer/issues/3451